### PR TITLE
Fixes two python module resolution errors (see extended commit msg)

### DIFF
--- a/src/sc2dsstats_rc1/sc2dsstats_rc1/dsdecode.cs
+++ b/src/sc2dsstats_rc1/sc2dsstats_rc1/dsdecode.cs
@@ -184,6 +184,8 @@ namespace sc2dsstats_rc1
             dynamic result = null;
             result = engine.ExecuteFile(exedir + @"\pylib\site-packages\mpyq.py", scope);
             if (result != null) Console.WriteLine(result);
+            result = engine.Execute("import s2protocol", scope);
+            if (result != null) Console.WriteLine(result);
             result = engine.Execute("from s2protocol import versions", scope);
             if (result != null) Console.WriteLine(result);
             //Thread.Sleep(1000);

--- a/src/sc2dsstats_rc1/sc2dsstats_rc1/pylib/site-packages/s2protocol/versions/__init__.py
+++ b/src/sc2dsstats_rc1/sc2dsstats_rc1/pylib/site-packages/s2protocol/versions/__init__.py
@@ -12,23 +12,20 @@ def _import_protocol(base_path, protocol_module_name):
     This implementation is derived from the __import__ example here:
         https://docs.python.org/2/library/imp.html
     """
-
-    # Try to return the module if it's been loaded already
+    imp.acquire_lock()
     try:
-        return sys.modules[protocol_module_name]
-    except KeyError:
-        pass
-
-    # If any of the following calls raises an exception,
-    # there's a problem we can't handle -- let the caller handle it.
-    #
-    fp, pathname, description = imp.find_module(protocol_module_name, [base_path])
-    try:
-        return imp.load_module(protocol_module_name, fp, pathname, description)
+        # If any of the following calls raises an exception,
+        # there's a problem we can't handle -- let the caller handle it.
+        #
+        fp, pathname, description = imp.find_module(protocol_module_name, [base_path])
+        try:
+            return imp.load_module(protocol_module_name, fp, pathname, description)
+        finally:
+            # Since we may exit via an exception, close fp explicitly.
+            if fp:
+                fp.close()
     finally:
-        # Since we may exit via an exception, close fp explicitly.
-        if fp:
-            fp.close()
+        imp.release_lock()
 
 
 def list_all(base_path=None):


### PR DESCRIPTION
`pylib/site-packages/s2protocol/versions/__init__.py` uses dynamic module loading and only does so if the module doesn't exist in sys.modules. 

However, this comes with issues in the context of IronPython. These modules are loaded multiple times in multiple ways, by multiple threads. To make things even more complicated, IronPython has its own module caching system which raises the number of moving parts, making diagnosing specific module loading issues a challenge.

Removing sys.modules from the versioned header loading of sc2dsstats seems to have solved one of the missing symbol issues. 

The other issue was corrected by pre-loading s2protocol before s2protocol.versions when launching the ScriptEngine.